### PR TITLE
fixed faccessat  a fd return error

### DIFF
--- a/unidbg-api/src/main/java/com/github/unidbg/unix/UnixSyscallHandler.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/unix/UnixSyscallHandler.java
@@ -116,6 +116,15 @@ public abstract class UnixSyscallHandler<T extends NewFileIO> implements Syscall
         if (failResult != null && failResult.isFallback()) {
             return FileResult.success(failResult.io);
         }
+        
+        if (pathname.indexOf(("/proc/" + emulator.getPid() + "/fd/")) == 0) {
+            int fd = Integer.parseInt(pathname.substring(pathname.lastIndexOf("/") + 1));
+            T file = fdMap.get(fd);
+            if (file != null) {
+                return FileResult.success(file);
+            }
+        }
+        
         return failResult;
     }
 


### PR DESCRIPTION
增加当 faccessat 的 pathname 为一个已经打开的文件fd, 如：faccessat dirfd=-100, pathname=/proc/2704/fd/3