### PR TITLE
修了关于内存对齐的bug

### DIFF
--- a/unidbg-android/src/main/java/com/github/unidbg/linux/AndroidElfLoader.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/AndroidElfLoader.java
@@ -400,7 +400,7 @@ public class AndroidElfLoader extends AbstractLoader<AndroidFileIO> implements M
                                 throw new IllegalStateException();
                             }
                             if (off > 0) {
-                                this.mem_map(base, off, UnicornConst.UC_PROT_NONE, libraryFile.getName(), off);
+                                backend.mem_map(base, off, prot);
                             }
                         }
                         lastAlignment = alignment;

--- a/unidbg-android/src/main/java/com/github/unidbg/linux/AndroidElfLoader.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/AndroidElfLoader.java
@@ -400,7 +400,10 @@ public class AndroidElfLoader extends AbstractLoader<AndroidFileIO> implements M
                                 throw new IllegalStateException();
                             }
                             if (off > 0) {
-                                backend.mem_map(base, off, prot);
+                                backend.mem_map(base, off, UnicornConst.UC_PROT_NONE);
+                                if (memoryMap.put(base, new MemoryMap(base, (int) off, UnicornConst.UC_PROT_NONE)) != null) {
+                                    log.warn("mem_map replace exists memory map base=" + Long.toHexString(base));
+                                }
                             }
                         }
                         lastAlignment = alignment;


### PR DESCRIPTION
在处理一个样本时一直发生内存分配问题，跟着log上去，审计下源码，发现是这个的计算对齐出现问题，实际上并不需要计算，看了源码，发现base和off在前面的计算，已经是对齐状态，不需要再算了，有可能就会出现计算错误的问题，所以建议不计算，直接分配