### PR TITLE
enhance the FileListener

### DIFF
--- a/unidbg-api/src/main/java/com/github/unidbg/unix/FileListener.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/unix/FileListener.java
@@ -2,13 +2,14 @@ package com.github.unidbg.unix;
 
 import com.github.unidbg.Emulator;
 import com.github.unidbg.file.FileIO;
+import com.sun.jna.Pointer;
 
 public interface FileListener {
 
     void onOpenSuccess(Emulator<?> emulator, String pathname, FileIO io);
 
-    void onRead(Emulator<?> emulator, String pathname, byte[] bytes);
-    void onWrite(Emulator<?> emulator, String pathname, byte[] bytes);
+    void onRead(Emulator<?> emulator, String pathname, Pointer buffer, byte[] bytes);
+    void onWrite(Emulator<?> emulator, String pathname, Pointer buffer, byte[] bytes);
 
     void onClose(Emulator<?> emulator, FileIO io);
 

--- a/unidbg-api/src/main/java/com/github/unidbg/unix/UnixSyscallHandler.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/unix/UnixSyscallHandler.java
@@ -261,7 +261,6 @@ public abstract class UnixSyscallHandler<T extends NewFileIO> implements Syscall
         if (log.isDebugEnabled()) {
             log.debug("read fd=" + fd + ", buffer=" + buffer + ", count=" + count + ", from=" + emulator.getContext().getLRPointer());
         }
-
         FileIO file = fdMap.get(fd);
         if (file == null) {
             emulator.getMemory().setErrno(UnixEmulator.EBADF);
@@ -278,7 +277,7 @@ public abstract class UnixSyscallHandler<T extends NewFileIO> implements Syscall
             } else {
                 bytes = buffer.getByteArray(0, read);
             }
-            fileListener.onRead(emulator, String.valueOf(file), bytes);
+            fileListener.onRead(emulator, String.valueOf(file), buffer, bytes);
         }
         return read;
     }
@@ -547,7 +546,7 @@ public abstract class UnixSyscallHandler<T extends NewFileIO> implements Syscall
             } else {
                 bytes = Arrays.copyOf(data, write);
             }
-            fileListener.onWrite(emulator, String.valueOf(file), bytes);
+            fileListener.onWrite(emulator, String.valueOf(file), buffer, bytes);
         }
         return write;
     }


### PR DESCRIPTION
在FileListener监听读写中增加buffer参数，这可以和Unicorn引擎所提供的内存读写监控形成良好的配好，让Unidbg可以更好的辅助算法还原。使用方式和场景类似如下代码
```
// 分析读取/proc/self/exe的意图
emulator.getSyscallHandler().setFileListener(new FileListener() {
    final String targetPathName = "/proc/self/exe";
    TraceHook traceHook;

    @Override
    public void onOpenSuccess(Emulator<?> emulator, String pathname, FileIO io) {
        if(pathname.equals(targetPathName)){
            System.out.println("Open File:"+pathname);
        }
    }

    @Override
    public void onRead(Emulator<?> emulator, String pathname, Pointer buffer, byte[] bytes) {
        if(pathname.equals(targetPathName)){
            System.out.println("start read it");
            UnidbgPointer unidbgPointer = (UnidbgPointer) buffer;
            long start = unidbgPointer.peer;
            long end = start + bytes.length - 1;
            traceHook = emulator.traceRead(start, end);
        }

    }

    @Override
    public void onWrite(Emulator<?> emulator, String pathname, Pointer buffer, byte[] bytes) {
        if(pathname.equals(targetPathName)){
            System.out.println("Writen bytes come from:"+ buffer);
        }
    }

    @Override
    public void onClose(Emulator<?> emulator, FileIO io) {
        String pathname = io.getPath();
        if(pathname.equals(targetPathName)){
            System.out.println("Close File:"+pathname);
            traceHook.stopTrace();
        }
    }
});
```

输出日志

```powershell
Open File:/proc/self/exe
start read it
[16:56:39 878] Memory READ at 0xbffff2fa, data size = 2, data value = 0xb700, PC=RX@0x4009ab84[libtest.so]0x9ab84, LR=RX@0x4009ab7c[libtest.so]0x9ab7c
Close File:/proc/self/exe
```
