### PR TITLE
多线程bug,deleteLocalRefs 删除 localObjectMap未考虑到多线程因素

### DIFF
--- a/unidbg-android/src/main/java/com/github/unidbg/linux/android/dvm/BaseVM.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/android/dvm/BaseVM.java
@@ -8,7 +8,10 @@ import com.github.unidbg.linux.android.ElfLibraryRawFile;
 import com.github.unidbg.linux.android.dvm.apk.Apk;
 import com.github.unidbg.linux.android.dvm.apk.ApkFactory;
 import com.github.unidbg.linux.android.dvm.apk.AssetResolver;
+import com.github.unidbg.linux.thread.MarshmallowThread;
 import com.github.unidbg.spi.LibraryFile;
+import com.github.unidbg.thread.Function32;
+import com.github.unidbg.thread.Function64;
 import net.dongliu.apk.parser.bean.CertificateMeta;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -92,7 +95,7 @@ public abstract class BaseVM implements VM, DvmClassFactory {
     final Map<Integer, ObjRef> globalObjectMap = new HashMap<>();
     final Map<Integer, ObjRef> weakGlobalObjectMap = new HashMap<>();
     final Map<Integer, ObjRef> localObjectMap = new HashMap<>();
-
+    final Map<Integer, Map> xLocalObjectMap = new HashMap<>();
     private DvmClassFactory dvmClassFactory;
 
     @Override
@@ -128,6 +131,32 @@ public abstract class BaseVM implements VM, DvmClassFactory {
         return new DvmClass(vm, className, superClass, interfaceClasses);
     }
 
+    public void putObj(int tid, int hash, ObjRef obj) {
+        Map objMap = xLocalObjectMap.get(tid);
+        if (objMap == null) {
+            objMap = new HashMap<>();
+        }
+        objMap.put(hash, obj);
+        xLocalObjectMap.put(tid, objMap);
+    }
+
+    public int getTid(){
+        Object obj = emulator.getThreadDispatcher().getRunningTask();
+        int tid;
+        if (obj == null) {
+            tid = emulator.getPid();
+        } else if (obj instanceof Function64) {
+            tid = ((Function64) obj).getId();
+        } else if (obj instanceof Function32) {
+            tid = ((Function32) obj).getId();
+        } else if (obj instanceof MarshmallowThread) {
+            tid = ((MarshmallowThread) obj).getId();
+        } else {
+            throw new RuntimeException("未知类型的RunningTask");
+        }
+        return tid;
+    }
+
     final int addObject(DvmObject<?> object, boolean global, boolean weak) {
         int hash = object.hashCode();
         if (log.isDebugEnabled()) {
@@ -144,7 +173,8 @@ public abstract class BaseVM implements VM, DvmClassFactory {
                 globalObjectMap.put(hash, new ObjRef(object, false));
             }
         } else {
-            localObjectMap.put(hash, new ObjRef(object, weak));
+            //localObjectMap.put(hash, new ObjRef(object, weak));
+            putObj(getTid(),hash, new ObjRef(object, weak));
         }
         return hash;
     }
@@ -171,8 +201,9 @@ public abstract class BaseVM implements VM, DvmClassFactory {
     @Override
     public final <T extends DvmObject<?>> T getObject(int hash) {
         ObjRef ref;
-        if (localObjectMap.containsKey(hash)) {
-            ref = localObjectMap.get(hash);
+        Map <Integer,ObjRef>_localObjectMap = xLocalObjectMap.get(getTid());
+        if (_localObjectMap.containsKey(hash)) {
+            ref = _localObjectMap.get(hash);
         } else if(globalObjectMap.containsKey(hash)) {
             ref = globalObjectMap.get(hash);
         } else {
@@ -187,10 +218,11 @@ public abstract class BaseVM implements VM, DvmClassFactory {
     }
 
     final void deleteLocalRefs() {
-        for (ObjRef ref : localObjectMap.values()) {
+        Map <Integer,ObjRef>_localObjectMap = xLocalObjectMap.get(getTid());
+        for (ObjRef ref : _localObjectMap.values()) {
             ref.obj.onDeleteRef();
         }
-        localObjectMap.clear();
+        _localObjectMap.clear();
 
         if (throwable != null) {
             throwable.onDeleteRef();


### PR DESCRIPTION
deleteLocalRefs 删除 localObjectMap未考虑到多线程因素（具体复现能在拼多多的libUserEnv.so）如：主线程还在用的元素，会被子线程给删除掉。解决方式：利用tid去创建和删除，将各个线程隔离开。查看代码，还有许多貌似的bug