### PR TITLE
fix: Avoid divide-by-zero exceptions

### DIFF
--- a/unidbg-android/src/main/java/net/fornwall/jelf/ElfDynamicStructure.java
+++ b/unidbg-android/src/main/java/net/fornwall/jelf/ElfDynamicStructure.java
@@ -165,6 +165,12 @@ public class ElfDynamicStructure {
 		// necessary DT_STRSZ is read.
 		int soName = -1;
 		int init = 0;
+		
+		// Avoid divide-by-zero exceptions
+		// rela struct 64bit: https://llvm.org/doxygen/structllvm_1_1ELF_1_1Elf64__Rela.html
+		// 32bit: https://llvm.org/doxygen/structllvm_1_1ELF_1_1Elf32__Rela.html
+		relEntrySize = elfFile.arch == ElfFile.CLASS_64 ? 24 : 12;
+
 		loop: for (int i = 0; i < numEntries; i++) {
 			long d_tag = parser.readIntOrLong();
 			final long d_val_or_ptr = parser.readIntOrLong();


### PR DESCRIPTION
sample code
```java
    public AntiOllvm() {
        emulator = AndroidEmulatorBuilder
                .for64Bit()
                .addBackendFactory(new Unicorn2Factory(true))
                .setProcessName("com.lgd.test")
                .build();
        Memory memory = emulator.getMemory();
        memory.setLibraryResolver(new AndroidResolver(31));
        vm = emulator.createDalvikVM();
        loadDepsLibs(vm);
        vm.setVerbose(true);
        dm = vm.loadLibrary(new File(SO_ROOT_DIR + "/libhelloollvm.so"), false);
        module = dm.getModule();
    }

    private void loadDepsLibs(VM vm) {
        vm.loadLibrary(new File(SO_LIB_DIR + "/libandroid.so"), false);
        vm.loadLibrary(new File(SO_LIB_DIR + "/liblog.so"), false);
        vm.loadLibrary(new File(SO_LIB_DIR + "/libm.so"), false);
        vm.loadLibrary(new File(SO_LIB_DIR + "/libdl.so"), false);
        vm.loadLibrary(new File(SO_LIB_DIR + "/libc.so"), false);
    }
```
error log 
```
Exception in thread "main" java.lang.ArithmeticException: / by zero
	at net.fornwall.jelf.ElfDynamicStructure.<init>(ElfDynamicStructure.java:327)
	at net.fornwall.jelf.ElfSegment$3.computeValue(ElfSegment.java:153)
	at net.fornwall.jelf.ElfSegment$3.computeValue(ElfSegment.java:150)
	at net.fornwall.jelf.MemoizedObject.getValue(MemoizedObject.java:21)
	at net.fornwall.jelf.ElfSegment.getDynamicStructure(ElfSegment.java:255)
	at com.github.unidbg.linux.AndroidElfLoader.loadInternal(AndroidElfLoader.java:434)
```