### PR TITLE
修复在threadDispatcher启用时，socket相关的读取造成的死锁问题

### DIFF
--- a/unidbg-android/src/main/java/com/github/unidbg/linux/ARM64SyscallHandler.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/ARM64SyscallHandler.java
@@ -31,6 +31,7 @@ import com.github.unidbg.linux.struct.RLimit64;
 import com.github.unidbg.linux.struct.Stat64;
 import com.github.unidbg.linux.thread.MarshmallowThread;
 import com.github.unidbg.linux.thread.PPollWaiter;
+import com.github.unidbg.linux.thread.ReceiveWaiter;
 import com.github.unidbg.memory.Memory;
 import com.github.unidbg.memory.SvcMemory;
 import com.github.unidbg.pointer.UnidbgPointer;
@@ -873,6 +874,15 @@ public class ARM64SyscallHandler extends AndroidSyscallHandler {
             emulator.getMemory().setErrno(UnixEmulator.EBADF);
             return -1;
         }
+
+        RunnableTask runningTask = emulator.getThreadDispatcher().getRunningTask();
+        if (threadDispatcherEnabled && runningTask != null) {
+            runningTask.setWaiter(emulator, new ReceiveWaiter(
+                    file, backend, buf, len, flags, src_addr, addrlen
+            ));
+            throw new ThreadContextSwitchException().setReturnValue(0);
+        }
+
         return file.recvfrom(backend, buf, len, flags, src_addr, addrlen);
     }
 

--- a/unidbg-android/src/main/java/com/github/unidbg/linux/file/PipedSocketIO.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/file/PipedSocketIO.java
@@ -39,4 +39,12 @@ public class PipedSocketIO extends TcpSocket implements FileIO {
         return super.sendto(data, flags, dest_addr, addrlen);
     }
 
+    @Override
+    public boolean canRead() {
+        try {
+            return pipedInputStream != null && pipedInputStream.available() > 0;
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
 }

--- a/unidbg-android/src/main/java/com/github/unidbg/linux/file/TcpSocket.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/file/TcpSocket.java
@@ -293,4 +293,18 @@ public class TcpSocket extends SocketIO implements FileIO {
     public String toString() {
         return socket.toString();
     }
+
+    @Override
+    public boolean canRead() {
+        try {
+            return inputStream != null && inputStream.available() > 0;
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean canWrite() {
+        return true;
+    }
 }

--- a/unidbg-android/src/main/java/com/github/unidbg/linux/thread/PPollWaiter.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/thread/PPollWaiter.java
@@ -1,0 +1,95 @@
+package com.github.unidbg.linux.thread;
+
+import com.github.unidbg.Emulator;
+import com.github.unidbg.file.FileIO;
+import com.github.unidbg.file.linux.AndroidFileIO;
+import com.github.unidbg.linux.file.TcpSocket;
+import com.github.unidbg.thread.AbstractWaiter;
+import com.sun.jna.Pointer;
+import unicorn.Arm64Const;
+import unicorn.ArmConst;
+
+import java.util.Map;
+
+public class PPollWaiter extends AbstractWaiter {
+
+    private final int nfds;
+    private final Emulator<?> emulator;
+    private final Pointer fds;
+    private final Pointer tmo_p;
+    private final Pointer sigmask;
+    private final Map<Integer, AndroidFileIO> fdMap;
+    private final long endWaitTimeInMillis;
+
+    public PPollWaiter(Emulator<?> emulator, Pointer fds, int nfds, Pointer tmo_p, Pointer sigmask,
+                       Map<Integer, AndroidFileIO> fdMap) {
+        this.emulator = emulator;
+        this.fds = fds;
+        this.nfds = nfds;
+        this.tmo_p = tmo_p;
+        this.sigmask = sigmask;
+        this.fdMap = fdMap;
+        long tv_sec = tmo_p.getLong(0);
+        long tv_nsec = tmo_p.getLong(8);
+        this.endWaitTimeInMillis = System.currentTimeMillis() + (
+                tv_sec * 1000L + tv_nsec / 1000000L
+                );
+    }
+
+    private static final short POLLIN = 0x0001;
+    private static final short POLLOUT = 0x0004;
+
+    @Override
+    public boolean canDispatch() {
+        int count = 0;
+        for (int i = 0; i < nfds; i++) {
+            Pointer pollfd = fds.share(i * 8L);
+            int fd = pollfd.getInt(0);
+            short events = pollfd.getShort(4); // requested events
+            if (fd >= 0) {
+                short revents = 0;
+                FileIO io = fdMap.get(fd);
+                if ((events & POLLOUT) != 0 && io.canWrite()) {
+                    revents = POLLOUT;
+                } else if ((events & POLLIN) != 0 && io.canRead()) {
+                    revents = POLLIN;
+                }
+                if (revents != 0) {
+                    pollfd.setShort(6, revents); // returned events
+                    count++;
+                }
+            }
+        }
+
+        return count > 0 || System.currentTimeMillis() > endWaitTimeInMillis;
+    }
+
+    @Override
+    public void onContinueRun(Emulator<?> emulator) {
+
+        int count = 0;
+        for (int i = 0; i < nfds; i++) {
+            Pointer pollfd = fds.share(i * 8L);
+            int fd = pollfd.getInt(0);
+            short events = pollfd.getShort(4); // requested events
+            if (fd < 0) {
+                pollfd.setShort(6, (short) 0);
+            } else {
+                short revents = 0;
+                FileIO io = fdMap.get(fd);
+                if ((events & POLLOUT) != 0 && io.canWrite()) {
+                    revents = POLLOUT;
+                } else if ((events & POLLIN) != 0 && io.canRead()) {
+                    revents = POLLIN;
+                }
+                if (revents != 0) {
+                    pollfd.setShort(6, revents); // returned events
+                    count++;
+                }
+            }
+        }
+
+        emulator.getBackend().reg_write(emulator.is32Bit() ? ArmConst.UC_ARM_REG_R0 : Arm64Const.UC_ARM64_REG_X0,
+                count);
+    }
+}

--- a/unidbg-android/src/main/java/com/github/unidbg/linux/thread/ReceiveWaiter.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/thread/ReceiveWaiter.java
@@ -1,0 +1,37 @@
+package com.github.unidbg.linux.thread;
+
+import com.github.unidbg.Emulator;
+import com.github.unidbg.arm.backend.Backend;
+import com.github.unidbg.file.FileIO;
+import com.github.unidbg.linux.file.SocketIO;
+import com.github.unidbg.thread.AbstractWaiter;
+import com.sun.jna.Pointer;
+import unicorn.Arm64Const;
+import unicorn.ArmConst;
+
+public class ReceiveWaiter extends AbstractWaiter {
+    private final Thread thread;
+    private int ret;
+
+    public ReceiveWaiter(FileIO file, Backend backend, Pointer buf, int len, int flags,
+                         Pointer src_addr, Pointer addrlen) {
+        this.thread = new Thread(() -> {
+            ret = file.recvfrom(backend, buf, len, flags, src_addr, addrlen);
+        });
+        this.thread.start();
+    }
+
+    @Override
+    public void onContinueRun(Emulator<?> emulator) {
+        emulator.getBackend().reg_write(emulator.is32Bit() ? ArmConst.UC_ARM_REG_R0 : Arm64Const.UC_ARM64_REG_X0,
+                ret);
+    }
+
+    @Override
+    public boolean canDispatch() {
+        if (this.thread.getState() == Thread.State.TERMINATED)
+            return true;
+        Thread.yield();
+        return false;
+    }
+}

--- a/unidbg-api/src/main/java/com/github/unidbg/file/AbstractFileIO.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/file/AbstractFileIO.java
@@ -177,6 +177,11 @@ public abstract class AbstractFileIO implements NewFileIO {
         return true;
     }
 
+    @Override
+    public boolean canWrite() {
+        return true;
+    }
+
     protected boolean stdio;
 
     @Override

--- a/unidbg-api/src/main/java/com/github/unidbg/file/FileIO.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/file/FileIO.java
@@ -2,6 +2,7 @@ package com.github.unidbg.file;
 
 import com.github.unidbg.Emulator;
 import com.github.unidbg.arm.backend.Backend;
+import com.github.unidbg.thread.Waiter;
 import com.sun.jna.Pointer;
 
 import java.io.IOException;
@@ -56,8 +57,9 @@ public interface FileIO {
     int llseek(long offset, Pointer result, int whence);
 
     int recvfrom(Backend backend, Pointer buf, int len, int flags, Pointer src_addr, Pointer addrlen);
-
+    
     String getPath();
 
     boolean isStdIO();
+
 }

--- a/unidbg-api/src/main/java/com/github/unidbg/file/FileIO.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/file/FileIO.java
@@ -12,6 +12,9 @@ public interface FileIO {
     int SEEK_CUR = 1;
     int SEEK_END = 2;
 
+    boolean canRead();
+    boolean canWrite();
+
     void close();
 
     int write(byte[] data);

--- a/unidbg-api/src/main/java/com/github/unidbg/file/NewFileIO.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/file/NewFileIO.java
@@ -2,6 +2,4 @@ package com.github.unidbg.file;
 
 public interface NewFileIO extends FileIO {
 
-    boolean canRead();
-
 }


### PR DESCRIPTION
在threadDispatcherEnabled时，由于使用抢先式调度，会导致socketpair在其中一个线程在接收时，持续占用调度，导致永远无法接收到发送线程的信息。

同理，由于ppoll没有考虑io是否有信息可读，会导致线程持续卡死在后接的recv中，导致实际运行逻辑与实际不符，同时如果其他线程正在同一socket准备发送请求，也会造成死锁。

详细样例可见本fork的master分支