### PR TITLE
增加支持在LinuxModule注册新的符号

### DIFF
--- a/unidbg-android/src/main/java/com/github/unidbg/linux/LinuxModule.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/LinuxModule.java
@@ -159,6 +159,9 @@ public class LinuxModule extends Module {
             if (withDependencies) {
                 return findDependencySymbolByName(name);
             }
+            if(hookMap.containsKey(name)){
+                return new VirtualSymbol(name,this,hookMap.get(name));
+            }
             return null;
         } catch (IOException e) {
             throw new IllegalStateException(e);

--- a/unidbg-android/src/main/java/com/github/unidbg/linux/LinuxModule.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/LinuxModule.java
@@ -159,8 +159,8 @@ public class LinuxModule extends Module {
             if (withDependencies) {
                 return findDependencySymbolByName(name);
             }
-            if(hookMap.containsKey(name)){
-                return new VirtualSymbol(name,this,hookMap.get(name));
+            if(addSymbolMap.containsKey(name)){
+                return addSymbolMap.get(name);
             }
             return null;
         } catch (IOException e) {
@@ -265,10 +265,16 @@ public class LinuxModule extends Module {
     }
 
     final Map<String, Long> hookMap = new HashMap<>();
+    final Map<String, Symbol> addSymbolMap = new HashMap<>();
 
     @Override
     public void registerSymbol(String symbolName, long address) {
-        hookMap.put(symbolName, address);
+        if(findSymbolByName(symbolName,false)==null){
+            addSymbolMap.put(symbolName,new VirtualSymbol(symbolName,this,address));
+        }else {
+            hookMap.put(symbolName, address);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
背景: 在模拟一个elf的文件执行时,该elf需要用到libdl.so的dlvsym函数,但我看了下unidbg带的so中仅支持dlsym函数，于是我手动实现该函数，并通过registerSvc注册进SvcMemory,再通过registerSymbol函数注册到libdl的Module里。

问题:当我注册进去后发现, elf中依旧找不到dlvsym函数，而我尝试通过module.findSymbolByName()和memory.dlsym()去寻找，依旧找不到dlvsym函数。

发现:我看了一下代码，对于系统库的LinuxMoudle而言,发现findSymbolByName仅从缓存和elf文件结构中寻找符号，而registerSymbol函数仅将符号添加到hook表，也就是说registerSymbol实际上只支持对elf文件中的符号进行hook(替换)，而无法添加符号函数。

解决:我认为如果仅是对现有符号进行hook，这非真正意义上的注册符号，所以我认为registerSymbol除了hook，应该还支持进行增加符号。