### PR TITLE
调整线程内存布局（减少最大线程数量，增加单个线程的栈内存大小）

### DIFF
--- a/unidbg-api/src/main/java/com/github/unidbg/memory/Memory.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/memory/Memory.java
@@ -12,7 +12,7 @@ public interface Memory extends IO, Loader, StackMemory {
 
     long STACK_BASE = 0xe5000000L;
 
-    int MAX_THREADS = 128;
+    int MAX_THREADS = 16;
     int STACK_SIZE_OF_THREAD_PAGE = MAX_THREADS * BaseTask.THREAD_STACK_PAGE; // for thread stack
     int STACK_SIZE_OF_MAIN_PAGE = 256; // for main stack
     int STACK_SIZE_OF_PAGE = STACK_SIZE_OF_THREAD_PAGE + STACK_SIZE_OF_MAIN_PAGE;

--- a/unidbg-api/src/main/java/com/github/unidbg/thread/BaseTask.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/thread/BaseTask.java
@@ -122,7 +122,7 @@ public abstract class BaseTask implements RunnableTask {
         }
     }
 
-    public static final int THREAD_STACK_PAGE = 8;
+    public static final int THREAD_STACK_PAGE = 64;
 
     protected final UnidbgPointer allocateStack(Emulator<?> emulator) {
         //stackBlock地址基于MMAP_BASE，必须想办法让它基于STACK_BASE(KVM在使用sp寄存器时会校验，校验失败直接升天）。

--- a/unidbg-api/src/main/java/com/github/unidbg/thread/BaseTask.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/thread/BaseTask.java
@@ -108,7 +108,7 @@ public abstract class BaseTask implements RunnableTask {
     public void destroy(Emulator<?> emulator) {
         Backend backend = emulator.getBackend();
 
-        if (stackSpaceAllocIndex > 0) {
+        if (stackSpaceAllocIndex != -1) {
             emulator.getMemory().freeThreadIndex(stackSpaceAllocIndex);
         }
 


### PR DESCRIPTION
最近so文件更新了，给我搞炸了，我找了半天还以为是线程调度的问题，因为tracecode明显乱跑。
后来发现原来是栈内存超了，A线程的栈内存侵占了B线程的栈内存，要命的是不会有任何错误提示。。。
这次我把栈内存变大，另外线程数量减少，因为线程数量超过了是可以看见详细报错提示的，超过线程数量产生的错误信息代价远比超过栈内存要好太多了