### PR TITLE
fix: Add missing fallbackJni.callStaticIntMethodV call in JniFunction class

### DIFF
--- a/unidbg-android/src/main/java/com/github/unidbg/linux/android/dvm/JniFunction.java
+++ b/unidbg-android/src/main/java/com/github/unidbg/linux/android/dvm/JniFunction.java
@@ -116,7 +116,7 @@ public abstract class JniFunction implements Jni {
         if (fallbackJni == null) {
             throw new UnsupportedOperationException(signature);
         } else {
-            return callStaticIntMethodV(vm, dvmClass, signature, vaList);
+            return fallbackJni.callStaticIntMethodV(vm, dvmClass, signature, vaList);
         }
     }
 


### PR DESCRIPTION
This fixes the issue where the fallback JNI implementation was not being invoked