### PR TITLE
ios: Fix arm64 ensure 16-byte SP alignment in callEntry(varargs)

### DIFF
--- a/unidbg-ios/src/main/java/com/github/unidbg/ios/MachOModule.java
+++ b/unidbg-ios/src/main/java/com/github/unidbg/ios/MachOModule.java
@@ -360,6 +360,15 @@ public class MachOModule extends Module implements com.github.unidbg.ios.MachO {
         }
 
         Pointer argvPointer = memory.allocateStack(0);
+
+        if (emulator.is64Bit()){
+            long currSP = memory.getStackPoint();
+            long mis = currSP & 0xF;
+            if (mis != 0) {
+                memory.allocateStack((int) mis);
+            }
+        }
+
         return emulateFunction(emulator, machHeader + entryPoint, argc, argvPointer, envPointer, auxvPointer).intValue();
     }
 

--- a/unidbg-ios/src/test/java/com/github/unidbg/ios/KQueue64Test.java
+++ b/unidbg-ios/src/test/java/com/github/unidbg/ios/KQueue64Test.java
@@ -32,7 +32,7 @@ public class KQueue64Test {
 
     private void test() {
         long start = System.currentTimeMillis();
-        module.callEntry(emulator);
+        module.callEntry(emulator,"1");
         System.out.println("offset=" + (System.currentTimeMillis() - start) + "ms, backend=" + emulator.getBackend());
     }
 


### PR DESCRIPTION
Fixes #757