### PR TITLE
fix: handle munmap across memory regions with different protection flags

### DIFF
--- a/unidbg-api/src/main/java/com/github/unidbg/spi/AbstractLoader.java
+++ b/unidbg-api/src/main/java/com/github/unidbg/spi/AbstractLoader.java
@@ -195,8 +195,13 @@ public abstract class AbstractLoader<T extends NewFileIO> implements Memory, Loa
                 long size = aligned - removed.size;
                 while (size != 0) {
                     MemoryMap remove = memoryMap.remove(address);
+                    if (remove == null) {
+                        log.warn("munmap failed to find adjacent region at address=0x{}", Long.toHexString(address));
+                        break;
+                    }
                     if (removed.prot != remove.prot) {
-                        throw new IllegalStateException();
+                        log.warn("munmap prot mismatch: removed.prot={}, remove.prot={}, address=0x{}", removed.prot,
+                                remove.prot, Long.toHexString(address));
                     }
                     address += remove.size;
                     size -= remove.size;


### PR DESCRIPTION
某些加壳的lib(如UPX)会在自解压完成后调用munmap，munmap这个操作可能会违反原本此处代码检查，因为跨越了两个保护标志不同的内存区域（如 prot=5 和 prot=0），导致 `AbstractLoader.munmap()` 第 199 行抛出 `IllegalStateException`。此提交放宽了检查，将throw改为了log warn.
已通过一个使用魔改UPX 加壳的 ARM64 so进行验证。修复前，该库加载失败；修复后，初始化函数顺利执行，代码页被正确解密，JNI_OnLoad 及后续原生方法调用均正常工作。

Some packed libs (such as UPX)may call `munmap` after self-extraction is complete. The munmap operation may violate the original code check here, as it spans memory regions with different protection flags (e.g., prot=5 and prot=0), causing `AbstractLoader.munmap()` line 199 to throw `IllegalStateException`. This commit relaxes the check, changing the throw to a log warn.
Verified with an ARM64 shared library using modified UPX packing.
Before the fix, the library fails to load. After the fix, the init
function completes successfully, code pages are properly decrypted,
and JNI_OnLoad + native method calls work correctly.