### PR TITLE
fix: byteSwap

### DIFF
--- a/.github/workflows/jitpack.yml
+++ b/.github/workflows/jitpack.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: "zulu"
-          java-version: "17"
+          java-version: "8"
       - run: |
           GIT_SHA=$(echo ${{ github.sha }} | cut -c1-10)
           mvn org.apache.maven.plugins:maven-dependency-plugin:3.9.0:get \

--- a/.github/workflows/jitpack.yml
+++ b/.github/workflows/jitpack.yml
@@ -1,0 +1,20 @@
+# The first time you request a project JitPack checks out the code, builds it and sends the Jar files back to you
+name: Jitpack
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - run: |
+          GIT_SHA=$(echo ${{ github.sha }} | cut -c1-10)
+          mvn org.apache.maven.plugins:maven-dependency-plugin:3.9.0:get \
+            -DremoteRepositories=https://jitpack.io \
+            -Dartifact=com.github.zhkl0228:unidbg:$GIT_SHA

--- a/unidbg-android/src/main/java/net/fornwall/jelf/ElfParser.java
+++ b/unidbg-android/src/main/java/net/fornwall/jelf/ElfParser.java
@@ -21,15 +21,15 @@ class ElfParser implements ElfDataIn {
 	 * Signed byte utility functions used for converting from big-endian (MSB) to little-endian (LSB).
 	 */
 	short byteSwap(short arg) {
-		return (short) ((arg << 8) | ((arg >>> 8) & 0xFF));
+		return Short.reverseBytes(arg);
 	}
 
 	int byteSwap(int arg) {
-		return ((byteSwap((short) arg)) << 16) | (((byteSwap((short) (arg >>> 16)))) & 0xFFFF);
+		return Integer.reverseBytes(arg);
 	}
 
 	long byteSwap(long arg) {
-		return ((((long) byteSwap((int) arg)) << 32) | (((long) byteSwap((int) (arg >>> 32)))));
+		return Long.reverseBytes(arg);
 	}
 
 	@Override


### PR DESCRIPTION
```java
public class Test {
    static short byteSwap(short arg) {
		return (short) ((arg << 8) | ((arg >>> 8) & 0xFF));
	}

	static int byteSwap(int arg) {
		return ((byteSwap((short) arg)) << 16) | (((byteSwap((short) (arg >>> 16)))) & 0xFFFF);
	}

	static long byteSwap(long arg) {
		return ((((long) byteSwap((int) arg)) << 32) | (((long) byteSwap((int) (arg >>> 32)))));
	}

    static long fixedByteSwap(long arg) {
        return Long.reverseBytes(arg);
    }

    public static void main(String[] args) {
        long x = 0x0000008000000001L;

        System.out.printf("input:  0x%016x%n", x);
        System.out.printf("old:    0x%016x%n", byteSwap(x));
        System.out.printf("fixed:  0x%016x%n", fixedByteSwap(x));
    }
}
```

这个 CI 可以提升第一个用的人的体验，反正 github actions 也不要钱